### PR TITLE
Missing assign IPrincipal to HttpContext

### DIFF
--- a/Allfiles/20487C/Mod04/DemoFiles/WebAPISecurity/WebAPISecurity/AuthenticationMessageHandler.cs
+++ b/Allfiles/20487C/Mod04/DemoFiles/WebAPISecurity/WebAPISecurity/AuthenticationMessageHandler.cs
@@ -54,6 +54,7 @@ namespace WebAPISecurity
                 IIdentity identity = new GenericIdentity(username);
                 IPrincipal principal = new GenericPrincipal(identity, new[] { "Users", "Admins" });
                 Thread.CurrentPrincipal = principal;
+                HttpContext.Current.User = principal;
                 return true;
             }
             return false;


### PR DESCRIPTION
If you try the demo as it is, never hit the controller because the AuthorizeAttribute return an Unauthorized. You have to assign the IPrincpial to the HttpContext.Current.User property. Thanks!