### PR TITLE
Module 11 Demo 1 outdated using clause

### DIFF
--- a/Instructions/20487C/20487C_MOD11_DEMO.md
+++ b/Instructions/20487C/20487C_MOD11_DEMO.md
@@ -49,7 +49,7 @@ Wherever you see a path to file starting with **[repository root]**, replace it 
    ```cs
         using System.Threading.Tasks;
         using Microsoft.Owin.Security.Notifications;
-        using Microsoft.IdentityModel.Protocols;
+        using Microsoft.IdentityModel.Protocols.OpenIdConnect;
    ```
 34.	Under **PostLogoutRedirectUri**, add the following piece of code:
    ```cs


### PR DESCRIPTION
Either incorrect or outdated using clause was used leading to a mismatch of signatures between the signature expected by SecurityTokenValidated and the OnTokenValidated function.

Closes #93 